### PR TITLE
Add `#[inline]` and `#[cold]` where useful to split out the cold path

### DIFF
--- a/src/endian.rs
+++ b/src/endian.rs
@@ -34,18 +34,22 @@ pub unsafe trait Endian: Copy + Clone {
 pub struct Native;
 
 unsafe impl Endian for Native {
+    #[inline]
     fn convert_u16(&self, bytes: [u8; 2]) -> u16 {
         u16::from_ne_bytes(bytes)
     }
 
+    #[inline]
     fn convert_u32(&self, bytes: [u8; 4]) -> u32 {
         u32::from_ne_bytes(bytes)
     }
 
+    #[inline]
     fn convert_u64(&self, bytes: [u8; 8]) -> u64 {
         u64::from_ne_bytes(bytes)
     }
 
+    #[inline]
     fn is_native(&self) -> bool {
         true
     }
@@ -56,18 +60,22 @@ unsafe impl Endian for Native {
 pub struct Little;
 
 unsafe impl Endian for Little {
+    #[inline]
     fn convert_u16(&self, bytes: [u8; 2]) -> u16 {
         u16::from_le_bytes(bytes)
     }
 
+    #[inline]
     fn convert_u32(&self, bytes: [u8; 4]) -> u32 {
         u32::from_le_bytes(bytes)
     }
 
+    #[inline]
     fn convert_u64(&self, bytes: [u8; 8]) -> u64 {
         u64::from_le_bytes(bytes)
     }
 
+    #[inline]
     fn is_native(&self) -> bool {
         let bytes = [b'a', b'b'];
 
@@ -80,18 +88,22 @@ unsafe impl Endian for Little {
 pub struct Big;
 
 unsafe impl Endian for Big {
+    #[inline]
     fn convert_u16(&self, bytes: [u8; 2]) -> u16 {
         u16::from_be_bytes(bytes)
     }
 
+    #[inline]
     fn convert_u32(&self, bytes: [u8; 4]) -> u32 {
         u32::from_be_bytes(bytes)
     }
 
+    #[inline]
     fn convert_u64(&self, bytes: [u8; 8]) -> u64 {
         u64::from_be_bytes(bytes)
     }
 
+    #[inline]
     fn is_native(&self) -> bool {
         let bytes = [b'a', b'b'];
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,10 +45,12 @@ impl ParseError {
     }
 
     /// Get the [`ErrorKind`] of this error.
+    #[inline]
     pub fn kind(&self) -> ErrorKind {
         self.code
     }
 
+    #[inline]
     const fn from_code(code: ErrorKind) -> Self {
         Self { code, source: None }
     }
@@ -58,6 +60,7 @@ impl ParseError {
     }
 
     /// More input was needed before the item could be successfully parsed.
+    #[inline]
     pub fn eof() -> Self {
         Self::from_code(ErrorKind::Eof)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ impl ParseError {
     }
 
     /// More input was needed before the item could be successfully parsed.
-    #[inline]
+    #[cold]
     pub fn eof() -> Self {
         Self::from_code(ErrorKind::Eof)
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -425,11 +425,11 @@ where
         self.parse_record_with_header(visitor, header)
     }
 
-    fn parse_record_impl<V: Visitor>(
+    fn parse_record_impl<V: Visitor<'p>>(
         &mut self,
         visitor: V,
         metadata: RecordMetadata,
-    ) -> Result<V::Output<'p>> {
+    ) -> Result<V::Output> {
         use perf_event_open_sys::bindings::*;
 
         Ok(match metadata.ty() {
@@ -459,11 +459,11 @@ where
 
     // Same as parse_record_impl but marked as #[slow]
     #[cold]
-    fn parse_record_slow<V: Visitor>(
+    fn parse_record_slow<V: Visitor<'p>>(
         &mut self,
         visitor: V,
         metadata: RecordMetadata,
-    ) -> Result<V::Output<'p>> {
+    ) -> Result<V::Output> {
         self.parse_record_impl(visitor, metadata)
     }
 

--- a/src/parsebuf.rs
+++ b/src/parsebuf.rs
@@ -190,7 +190,7 @@ impl<'p> ParseBufCursor<'p> {
 
         match &self.chunks[0] {
             Cow::Borrowed(data) => Some(*data),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/src/records/mmap2.rs
+++ b/src/records/mmap2.rs
@@ -40,6 +40,7 @@ impl<'a> Mmap2<'a> {
     }
 
     /// Convert this record to a [`Mmap`] record.
+    #[inline]
     pub fn into_mmap(self) -> Mmap<'a> {
         Mmap {
             pid: self.pid,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -16,6 +16,7 @@ pub struct RecordMetadata {
 }
 
 impl RecordMetadata {
+    #[inline]
     pub(crate) fn new(header: bindings::perf_event_header, sample_id: SampleId) -> Self {
         Self {
             ty: header.type_,
@@ -25,11 +26,13 @@ impl RecordMetadata {
     }
 
     /// The type of this record, as emitted by the kernel.
+    #[inline]
     pub fn ty(&self) -> u32 {
         self.ty
     }
 
     /// Miscellaneous flags set by the kernel.
+    #[inline]
     pub fn misc(&self) -> MiscFlags {
         self.misc
     }
@@ -41,6 +44,7 @@ impl RecordMetadata {
     /// always have an empty `SampleId`. If you want the `SampleId` fields
     /// to be set then configure the kernel to generate MMAP2 records
     /// instead.
+    #[inline]
     pub fn sample_id(&self) -> &SampleId {
         &self.sample_id
     }


### PR DESCRIPTION
LLVM seems to have a hard time properly inlining the various utility methods in the parser. By strategically adding `#[inline]` and `#[cold]` annotations and splitting out the hot and cold path this PR makes so that llvm is able to inline almost the entirety of `parse_record_impl` and reap the resulting optimizations.