### PR TITLE
Simplify CowSliceExt::split_at

### DIFF
--- a/src/cowutils.rs
+++ b/src/cowutils.rs
@@ -26,8 +26,7 @@ where
             Self::Owned(data) if len == 0 => (data.into(), Cow::Borrowed(&[])),
             Self::Owned(data) if len == data.len() => (Cow::Borrowed(&[]), data.into()),
             Self::Owned(mut data) => {
-                let rest = data.split_at(len).1.to_vec();
-                data.truncate(len);
+                let rest: Vec<T> = data.drain(len..).collect();
                 (data.into(), rest.into())
             }
         }


### PR DESCRIPTION
As it turns out, Vec::drain can be used to move the elements to a separate vector without needing to clone them.