### PR TITLE
Remove `BranchSampleType`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
-use perf_event_open_sys::bindings::perf_event_attr;
+use perf_event_open_sys::bindings::{perf_event_attr, PERF_SAMPLE_BRANCH_HW_INDEX};
 
 use crate::endian::Endian;
-use crate::flags::BranchSampleFlags;
 use crate::{ReadFormat, SampleFlags};
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -89,8 +88,7 @@ impl From<perf_event_attr> for RawParseConfig {
             read_format: ReadFormat::from_bits_retain(attrs.read_format),
             sample_regs_user: attrs.sample_regs_user,
             sample_regs_intr: attrs.sample_regs_intr,
-            branch_hw_index: BranchSampleFlags::from_bits_retain(attrs.branch_sample_type)
-                .contains(BranchSampleFlags::HW_INDEX),
+            branch_hw_index: (attrs.branch_sample_type & PERF_SAMPLE_BRANCH_HW_INDEX as u64) != 0,
             sample_id_all: attrs.sample_id_all() != 0,
         }
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -47,7 +47,6 @@ bitflags! {
     }
 }
 
-
 bitflags! {
     /// Flags that control what data is returned when reading from a
     /// perf_event file descriptor.

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -47,30 +47,6 @@ bitflags! {
     }
 }
 
-bitflags! {
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
-    pub struct BranchSampleFlags : u64 {
-        const USER          = bindings::PERF_SAMPLE_BRANCH_USER as _;
-        const KERNEL        = bindings::PERF_SAMPLE_BRANCH_KERNEL as _;
-        const HV            = bindings::PERF_SAMPLE_BRANCH_HV as _;
-        const ANY           = bindings::PERF_SAMPLE_BRANCH_ANY as _;
-        const ANY_CALL      = bindings::PERF_SAMPLE_BRANCH_ANY_CALL as _;
-        const ANY_RETURN    = bindings::PERF_SAMPLE_BRANCH_ANY_RETURN as _;
-        const IND_CALL      = bindings::PERF_SAMPLE_BRANCH_IND_CALL as _;
-        const ABORT_TX      = bindings::PERF_SAMPLE_BRANCH_ABORT_TX as _;
-        const IN_TX         = bindings::PERF_SAMPLE_BRANCH_IN_TX as _;
-        const NO_TX         = bindings::PERF_SAMPLE_BRANCH_NO_TX as _;
-        const COND          = bindings::PERF_SAMPLE_BRANCH_COND as _;
-        const CALL_STACK    = bindings::PERF_SAMPLE_BRANCH_CALL_STACK as _;
-        const IND_JUMP      = bindings::PERF_SAMPLE_BRANCH_IND_JUMP as _;
-        const CALL          = bindings::PERF_SAMPLE_BRANCH_CALL as _;
-        const NO_FLAGS      = bindings::PERF_SAMPLE_BRANCH_NO_FLAGS as _;
-        const NO_CYCLES     = bindings::PERF_SAMPLE_BRANCH_NO_CYCLES as _;
-        const TYPE_SAVE     = bindings::PERF_SAMPLE_BRANCH_TYPE_SAVE as _;
-        const HW_INDEX      = bindings::PERF_SAMPLE_BRANCH_HW_INDEX as _;
-        const PRIV_SAVE     = bindings::PERF_SAMPLE_BRANCH_PRIV_SAVE as _;
-    }
-}
 
 bitflags! {
     /// Flags that control what data is returned when reading from a


### PR DESCRIPTION
It is not used for any public-facing methods and so it should probably be in perf-event2