### PR TITLE
Simplify how `Read` and `read_value` types are exposed

### DIFF
--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -187,7 +187,7 @@ pub enum Record<'a> {
     Throttle(Throttle),
     Unthrottle(Throttle),
     Fork(Fork),
-    Read(Read<'a>),
+    Read(Read),
     Sample(Box<Sample<'a>>),
     Mmap2(Mmap2<'a>),
     Aux(Aux),
@@ -241,7 +241,7 @@ record_from!(Comm<'a>);
 // These are both the same struct
 // record_from!(Exit);
 // record_from!(Fork);
-record_from!(Read<'a>);
+record_from!(Read);
 record_from!(Mmap2<'a>);
 record_from!(Aux);
 record_from!(ITraceStart);
@@ -300,7 +300,7 @@ impl<'a> crate::Visitor<'a> for RecordVisitor {
         Record::Fork(record)
     }
 
-    fn visit_read(self, record: Read<'a>, _: crate::RecordMetadata) -> Self::Output {
+    fn visit_read(self, record: Read, _: crate::RecordMetadata) -> Self::Output {
         record.into()
     }
 

--- a/src/records/read.rs
+++ b/src/records/read.rs
@@ -66,6 +66,7 @@ impl<'a> ReadData<'a> {
     }
 }
 
+/// Data read from a counter.
 #[derive(Clone)]
 pub struct ReadValue {
     read_format: ReadFormat,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -122,7 +122,7 @@ pub trait Visitor<'a>: Sized {
     }
 
     /// Visit a [`Read`] record.
-    fn visit_read(self, record: Read<'a>, metadata: RecordMetadata) -> Self::Output {
+    fn visit_read(self, record: Read, metadata: RecordMetadata) -> Self::Output {
         self.visit_unimplemented(metadata)
     }
 


### PR DESCRIPTION
As it turns out, PERF_RECORD_READ events are only emitted when the inherit and inherit_stat flags are set. inherit is incompatible with READ_FORMAT_GROUP so PERF_RECORD_READ will never be emitted with a group format. This PR takes advantage of that to simplify some things and I've also gone and rethought how `ReadGroup` and `ReadValue` should be used.

- Sample now always contains a ReadGroup and converts if the source read_format is only for a single value.
- Read now only contains a ReadValue since it is not possible to create a Read record when GROUP is set in read_format
- ReadGroup can now be converted into ReadValue via TryFrom
- ReadValue can now be converted into ReadGroup via From
- ReadData has been deleted since the conversions take its place