### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.2] - 2023-05-16
 ### Changed
 - Fixed compile breakage due to https://github.com/bitflags/bitflags/issues/353
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event-data"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Sean Lynch <sean@lynches.ca>"]


### PR DESCRIPTION
## [0.1.2] - 2023-05-16
### Changed
- Fixed compile breakage due to https://github.com/bitflags/bitflags/issues/353