### PR TITLE
Prepare to release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.3] - 2023-10-23
 ### Added
 - `Parse` is now implemented for `perf_event_attr` from `perf_event_open_sys2`.
 
@@ -28,3 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2023-05-14
 This is the very first release of the `perf-event-data` crate.
+
+[Unreleased]: https://github.com/phantomical/perf-event/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/phantomical/perf-event/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/phantomical/perf-event/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/phantomical/perf-event/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/phantomical/perf-event/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event-data"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Sean Lynch <sean@lynches.ca>"]


### PR DESCRIPTION
## [0.1.3] - 2023-10-23
### Added
- `Parse` is now implemented for `perf_event_attr` from `perf_event_open_sys2`.

### Changed
- The debug representation of several record types has been changed to make it more readable.

### Fixed
- Fixed an infinite loop with unbounded memory usage in `ParseBufCursor::new` when the first chunk returned by the `ParseBuf` had length 0.