### PR TITLE
Improve the debug formatting of build_id within Mmap2 records

### DIFF
--- a/src/records/mmap2.rs
+++ b/src/records/mmap2.rs
@@ -236,7 +236,7 @@ impl fmt::Debug for Mmap2<'_> {
             }
             MmapDetail::BuildId { .. } => {
                 if let Some(build_id) = self.build_id() {
-                    dbg.field("build_id", &build_id);
+                    dbg.field("build_id", &crate::util::fmt::HexStr(build_id));
                 }
             }
         }

--- a/src/util/fmt.rs
+++ b/src/util/fmt.rs
@@ -41,6 +41,29 @@ impl fmt::Debug for ByteStr<'_> {
     }
 }
 
+/// Format a byte array as hex.
+pub(crate) struct HexStr<'a>(pub &'a [u8]);
+
+impl fmt::Debug for HexStr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for &b in self.0 {
+            let nibbles = [b & 0xF, b >> 4];
+
+            for n in nibbles {
+                let c = match n {
+                    0x0..=0x9 => b'0' + n,
+                    0xA..=0xF => b'A' + n,
+                    _ => unreachable!(),
+                };
+
+                f.write_char(c as char)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 pub(crate) struct HexAddr<T>(pub T);
 
 impl<T: UpperHex> fmt::Debug for HexAddr<T> {


### PR DESCRIPTION
This formats the field as straight hex, with no quoting or anything else.