### PR TITLE
Fix `PERF_SAMPLE_RAW` parsing

### DIFF
--- a/src/records/sample.rs
+++ b/src/records/sample.rs
@@ -195,7 +195,7 @@ impl<'p> Parse<'p> for Sample<'p> {
             unsafe { p.parse_slice(nr) }
         })?;
         let raw = p.parse_if_with(sty.contains(SampleFlags::RAW), |p| {
-            let size = p.parse_u64()? as _;
+            let size = p.parse_u32()? as _;
             p.parse_bytes(size)
         })?;
         let lbr = p.parse_if_with(sty.contains(SampleFlags::BRANCH_STACK), |p| {


### PR DESCRIPTION
The size is actually `u32`. Fixes parsing when `PERF_SAMPLE_RAW` is used.

https://man7.org/linux/man-pages/man2/perf_event_open.2.html
>  size, data[size]
>    If PERF_SAMPLE_RAW is enabled, then a 32-bit value
>    indicating size is included followed by an array
>    of 8-bit values of length size.  The values are
>    padded with 0 to have 64-bit alignment.