### PR TITLE
Pad PERF_SAMPLE_RAW field out to next u64 alignment when parsing

### DIFF
--- a/src/records/sample.rs
+++ b/src/records/sample.rs
@@ -195,8 +195,10 @@ impl<'p> Parse<'p> for Sample<'p> {
             unsafe { p.parse_slice(nr) }
         })?;
         let raw = p.parse_if_with(sty.contains(SampleFlags::RAW), |p| {
-            let size = p.parse_u32()? as _;
-            p.parse_bytes(size)
+            p.parse_padded(std::mem::size_of::<u64>(), |p| {
+                let size = p.parse_u32()? as _;
+                p.parse_bytes(size)
+            })
         })?;
         let lbr = p.parse_if_with(sty.contains(SampleFlags::BRANCH_STACK), |p| {
             let nr = p.parse_u64()? as usize;


### PR DESCRIPTION
The manpage mentions that

> If PERF_SAMPLE_RAW is enabled, then a 32-bit value indicating size
> is included followed by an array of 8-bit values of length size.
> The values are padded with 0 to have 64-bit alignment.

We were not including the padding so this would be subtly wrong if a raw sampler ever included data whose size was not a multiple of 64. Most accesses of hardware counters would not run into this but emitting data from a BPF program might.