### PR TITLE
Avoid parsing the dyn_size field in sample stack when size is 0

### DIFF
--- a/src/records/sample.rs
+++ b/src/records/sample.rs
@@ -214,8 +214,14 @@ impl<'p> Parse<'p> for Sample<'p> {
         })?;
         let stack_user = p.parse_if_with(sty.contains(SampleFlags::STACK_USER), |p| {
             let size = p.parse_u64()? as usize;
+
             let mut data = p.parse_bytes(size)?;
-            let dyn_size = p.parse_u64()? as usize;
+
+            // from the manpage: dyn_size is omitted if size is 0.
+            let dyn_size = match size {
+                0 => 0,
+                _ => p.parse_u64()? as usize,
+            };
 
             if dyn_size > data.len() {
                 return Err(ParseError::custom(


### PR DESCRIPTION
The manpage indicates that the dyn_size field is emitted if size is 0.

> Note that dyn_size is omitted if size is 0.

The current code unconditionally attempts to parse dyn_size. This is wrong. The fix is to only parse dyn_size when size != 0.