### PR TITLE
Allow constructing SampleId from Samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow constructing a `SampleId` from a `Sample`.
 
 ## [0.1.7] - 2025-01-18
 ### Fixed

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -80,6 +80,19 @@ use crate::prelude::*;
 pub struct SampleId(sample_id::SampleId);
 
 impl SampleId {
+    /// Construct a `SampleId` by reading its fields out of a full sample
+    /// struct.
+    pub fn from_sample(sample: &Sample<'_>) -> Self {
+        Self(sample_id::SampleId::new(
+            sample.pid(),
+            sample.tid(),
+            sample.time(),
+            sample.id(),
+            sample.stream_id(),
+            sample.cpu(),
+        ))
+    }
+
     /// The process ID that generated this event.
     pub fn pid(&self) -> Option<u32> {
         self.0.pid().copied()
@@ -170,6 +183,18 @@ impl<'p> Parse<'p> for SampleId {
 impl fmt::Debug for SampleId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl From<&'_ Sample<'_>> for SampleId {
+    fn from(value: &Sample) -> Self {
+        Self::from_sample(value)
+    }
+}
+
+impl From<Sample<'_>> for SampleId {
+    fn from(value: Sample<'_>) -> Self {
+        Self::from_sample(&value)
     }
 }
 


### PR DESCRIPTION
This is needed in order to support generic logic to read a SampleId from all records except MMAP.